### PR TITLE
Fixed vertical alignment of loader animation so it's closer to the title

### DIFF
--- a/views/placeholder.html
+++ b/views/placeholder.html
@@ -50,16 +50,14 @@ maximum-scale=1.0 user-scalable=no" />
   </head>
   <body>
     <div id="mid">
-            <h1 class="splashlogo">SXDiscover</h1>
+      <h1 class="splashlogo">SXDiscover</h1>
+      <div id="animation">
+       <div class="loader-inner ball-pulse">
+        <div id="red"></div>
+        <div id="yellow"></div>
+        <div id="turqoise"></div>
       </div>
-    <div id="mid-loader">
-        <div id="animation">
-         <div class="loader-inner ball-pulse">
-          <div id="red"></div>
-          <div id="yellow"></div>
-          <div id="turqoise"></div>
-         </div>
-        </div>
     </div>
+  </div>
   </body>
 </html>


### PR DESCRIPTION
After:
![screenshot 2018-03-07 19 55 59](https://user-images.githubusercontent.com/12538763/37128856-9d4cdc78-2241-11e8-8491-8dfd8fb453aa.png)
