### PR TITLE
adding placeholders when no bands found

### DIFF
--- a/public/stylesheets/summary.css
+++ b/public/stylesheets/summary.css
@@ -15,10 +15,19 @@ body {
 
 .helper{
     font-family: SharpGroteskMedium20;
-    line-height: 1.4em;
+    line-height: 1.2em;
     font-size: 1.2em;
-    margin-top: 2.5em;
+    margin-top: 2em;
     margin-bottom: 1.5em;
+}
+
+.no-shows-placeholder{
+    font-family: SharpGroteskMedium20;
+    line-height: 1.2em;
+    font-size: 0.8em;
+    margin-top: 1.1em;
+    margin-bottom: 1.1em;
+    text-align: center;
 }
 
 .band{

--- a/public/stylesheets/userpage.css
+++ b/public/stylesheets/userpage.css
@@ -19,6 +19,16 @@ body {
     height: 4em;
 }
 
+.no-shows-placeholder{
+    font-family: SharpGroteskMedium20;
+    line-height: 1.2em;
+    font-size: 1.5em;
+    margin-top: 3em;
+    margin-bottom: 3em;
+    margin-left: 1em;
+    margin-right: 1em;
+}
+
 .add-shows-tooltip__text{
     display: table-cell;
     vertical-align: middle;

--- a/views/summary.html
+++ b/views/summary.html
@@ -19,11 +19,17 @@
 </head>
 <body>
   <div class="container">
+    {{#if bands}}
     <div class="helper">Based on the artists you love, here’s who’s playing at SXSW this year:</div>
+    {{/if}}
     <div id="band" class="band">
       <!-- Using some Handlebars magic to iterate through the bands array that's passed in -->
       {{#each bands}}
       <div class="band__name">{{this}}</div>
+      {{else}}
+      <!-- show placehodler text if no bands in the list-->
+      <div class="helper" align="center">No shows found yet 😞</div><p><p>
+      <div class="no-shows-placeholder">Don't worry – new shows are added every day. Check back soon!</div>
       {{/each}}
     </div>
   </div>

--- a/views/userPage.html
+++ b/views/userPage.html
@@ -51,8 +51,9 @@
     </script>
     <script>
 
+
       $(document).ready(function() {
-        vex.dialog.alert({ unsafeMessage: 'Here\'s your SXSW schedule for the week, pulled from your top Spotify artists and their related artists. <br /><br />✌🏽✌🏻,<br />- Ben + Mathew'})
+        vex.dialog.alert({ unsafeMessage: 'Here\'s your SXSW schedule for the week, pulled from your top Spotify artists and their related artists. <br /><br />✌🏽✌🏻,<br />- Mathew + Ben'})
       });
 
       // Function that adds an event handler for each "Save to calendar button". index tells us which date and show the "Save to calendar" button was clicked for.
@@ -109,6 +110,7 @@
     </div>
 
     <div class="showlist">
+      {{#if shows}}
       <form name="showsForm">
         {{#each shows}}
         <div class="show__day">{{this.day}}, March {{this.date}}</div>
@@ -141,6 +143,12 @@
         {{/each}}
         {{/each}}
       </form>
+      {{else}}
+    </div> 
+      <br /><br />
+      <div class="no-shows-placeholder">No shows found yet 😞</div>
+      <div class="no-shows-placeholder">Don't worry – new shows are added every day. Check back soon!</div>
+      {{/if}}
     </div>
     <div class="go-to-schedule" id="go-to-schedule">
       <div class="go-to-schedule__button-text">


### PR DESCRIPTION
Used new Handlebars logic to detect if any bands were found. If no bands, added some ugly placeholder text. (It's ugly but better than blank state, which it was before)

https://handlebarsjs.com/builtin_helpers.html

<img width="376" alt="screenshot 2019-02-10 17 20 42" src="https://user-images.githubusercontent.com/13950154/52541217-3620c500-2d58-11e9-95a7-a5a2872b4ec4.png">
