### PR TITLE
Fixed band list hiding behind bottom button

### DIFF
--- a/public/stylesheets/summary.css
+++ b/public/stylesheets/summary.css
@@ -33,6 +33,7 @@ body {
 .band{
     font-size: 2em;
     font-family: SharpGroteskSemiBold22;
+    margin-bottom: 4em;
 }
 
 .band__name{

--- a/public/stylesheets/userpage.css
+++ b/public/stylesheets/userpage.css
@@ -37,6 +37,7 @@ body {
 .showlist{
     margin: 0 auto;
     margin-top: 6em;
+    margin-bottom: 10em;
 }
 
 .show{


### PR DESCRIPTION
Fix for https://trello.com/c/hpqL4KKJ/33-band-list-in-summary-page-and-user-page-hides-behind-bottom-button