### PR TITLE
Added route for individual shows

### DIFF
--- a/models/band.js
+++ b/models/band.js
@@ -12,7 +12,7 @@ var bandSchema = mongoose.Schema({
   showId: String
 });
 
-var Band = exports.model = mongoose.model('_2019-02-10', bandSchema);
+var Band = exports.model = mongoose.model('_2019-02-11', bandSchema);
 var priceMap = require('../public/javascripts/priceMapping.js')
 
 exports.fetchBandInfo = function(bandList, callback){

--- a/public/stylesheets/show.css
+++ b/public/stylesheets/show.css
@@ -28,26 +28,34 @@ body {
     line-height: 1.3em;
 }
 
-/* Setting it up as a table so I can get vertically center the button text */
-.view-your-schedule{
+.subtitle{
     position: fixed;
-    bottom: 0;
-    font-family: Raleway-ExtraBold;
-    font-size: 1.5em;
-    display: table;
     text-align: center;
+    font-weight: 600;
+    font-size: 1em;
+    bottom: 6.5em;
+    left: 50%;
+    transform: translateX(-50%);
     width: 100%;
-    background-color: #32ABB7;
-    height: 4em;
+    padding: 0 2em;
 }
 
-.view-your-schedule:hover{
-    background-color: #FFFFFF;
-    color: #383838;
+.spotify-button{
+    width: 299px;
+    height: 49px;
+    position: fixed;
     cursor: pointer;
+    bottom: 0.5em;
+    margin-bottom: 2em;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
-.view-your-schedule__button-text{
-    display: table-cell;
-    vertical-align: middle;
+.spotify-button.no-text{
+    cursor: default;
+    background: #1DB954;
+    border-radius: 35px;
+    font-family: Raleway-Medium;
+    font-size: 17px;
+    color: #FFFFFF;
 }

--- a/public/stylesheets/show.css
+++ b/public/stylesheets/show.css
@@ -1,0 +1,53 @@
+body {
+  background: #383838;
+  font-family: 'Raleway', sans-serif;
+  color: white;
+}
+
+.container{
+    display: table;
+    margin: 0 auto;
+    padding-left: 2em;
+    padding-right: 2em;
+    height: 80vh;
+}
+
+.container__content{
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.container__content__band-name{
+    font-weight: 800;
+    font-size: 3em;
+}
+
+.container__content__show-info{
+    font-weight: 600;
+    font-size: 1.6em;
+    line-height: 1.3em;
+}
+
+/* Setting it up as a table so I can get vertically center the button text */
+.view-your-schedule{
+    position: fixed;
+    bottom: 0;
+    font-family: Raleway-ExtraBold;
+    font-size: 1.5em;
+    display: table;
+    text-align: center;
+    width: 100%;
+    background-color: #32ABB7;
+    height: 4em;
+}
+
+.view-your-schedule:hover{
+    background-color: #FFFFFF;
+    color: #383838;
+    cursor: pointer;
+}
+
+.view-your-schedule__button-text{
+    display: table-cell;
+    vertical-align: middle;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,6 @@
 var express = require('express');
 var router = express.Router();
+var Band = require('../models/band.js'); // Get Show info
 
 /* Get comingSoon page. */
 router.get('/', function(req, res, next) {
@@ -28,6 +29,9 @@ router.get('/privacy-policy', function(req, res, next){
   res.render('privacy-policy');
   console.log("Fetching privacy page. Current memory usage is "+(Math.round(process.memoryUsage().heapUsed/1048576))+" MB.")
 });
+
+/* Load page for a specific show ID. */
+router.use('/', require('./show'));
 
 /* Load itinerary for a specific venue. */
 router.use('/', require('./venues'));

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,9 +9,8 @@ router.get('/', function(req, res, next) {
 });
 
 /* Get home page. */
-router.get('/secretentrypoint', function(req, res, next) {
+router.get('/s', function(req, res, next) {
   res.render('index');
-  console.log("Fetching homepage. Current memory usage is "+(Math.round(process.memoryUsage().heapUsed/1048576))+" MB.")
 });
 
 /* Get about page. */

--- a/routes/show.js
+++ b/routes/show.js
@@ -6,7 +6,6 @@ var Band = require('../models/band.js');
 
 router.get('/show/*', function(req, res, next){
   try{
-    console.log("Show ID is "+req.params[0])
     Band.model.find({showId: { $in: req.params[0]}}).exec(function (err, docs){
       if(err){
         // Error fetching anything from the database.
@@ -14,15 +13,13 @@ router.get('/show/*', function(req, res, next){
         res.sendStatus(404);
       } else {
         try{
-          console.log(docs)
           var results = JSON.stringify(docs)
-          console.log(results);
           var name = docs[0].name
           var venue = docs[0].venue
           var date = docs[0].date
           var time = docs[0].time
 
-          res.render('show', {name:name, venue: venue, date:date, time:time})
+          res.render('show', {name:name, venue:venue, date:date, time:time})
         } catch(e){
           // Error: We fetched something from the database but hit an error trying to parse it.
           console.log("We fetched something from the database but hit an error trying to parse it.")

--- a/routes/show.js
+++ b/routes/show.js
@@ -1,0 +1,41 @@
+// Route that's called to access a full page view for a specific show
+
+var express = require('express');
+var router = express.Router();
+var Band = require('../models/band.js');
+
+router.get('/show/*', function(req, res, next){
+  try{
+    console.log("Show ID is "+req.params[0])
+    Band.model.find({showId: { $in: req.params[0]}}).exec(function (err, docs){
+      if(err){
+        // Error fetching anything from the database.
+        console.log("Error fetching anything from the database.")
+        res.sendStatus(404);
+      } else {
+        try{
+          console.log(docs)
+          var results = JSON.stringify(docs)
+          console.log(results);
+          var name = docs[0].name
+          var venue = docs[0].venue
+          var date = docs[0].date
+          var time = docs[0].time
+
+          res.render('show', {name:name, venue: venue, date:date, time:time})
+        } catch(e){
+          // Error: We fetched something from the database but hit an error trying to parse it.
+          console.log("We fetched something from the database but hit an error trying to parse it.")
+
+          // TODO: This most likely happens when we don't find a show. We should show an error message with an option to go back to the homepage.
+          res.sendStatus(404);
+        }
+      }
+    })
+  } catch(e){
+    console.log("Error searching database")
+    res.sendStatus(404);
+  }
+});
+
+module.exports = router;

--- a/views/show.html
+++ b/views/show.html
@@ -19,10 +19,18 @@
 </head>
 <body>
   <div class="container">
-
+    <div class="container__content">
+      <div class="container__content__band-name">{{name}}</div>
+      <div class="container__content__show-info">is playing {{venue}} on {{date}} at {{time}}.</div>
+    </div>
   </div>
-  <div id="view-all-results" class="view-all-results">
-    <div class="view-all-results__button-text">VIEW ALL RESULTS</div>
+  <div id="view-your-schedule" class="view-your-schedule">
+    <div class="view-your-schedule__button-text">GET YOUR OWN SCHEDULE</div>
   </div>
+  <script>
+    $('#view-your-schedule').click(function(){
+      window.location.replace("https://www.sxdiscover.com");
+    })
+  </script>
 </body>
 </html>

--- a/views/show.html
+++ b/views/show.html
@@ -4,6 +4,7 @@
   <title></title>
   <link rel="stylesheet" href="/stylesheets/reset.css">
   <link rel="stylesheet" href="/stylesheets/show.css">
+  <link rel="stylesheet" type="text/css" href="/stylesheets/loader.css">
   <meta name="viewport" content="width=device-width initial-scale = 1.0
   maximum-scale=1.0 user-scalable=no" />
   <script>
@@ -24,13 +25,18 @@
       <div class="container__content__show-info">is playing {{venue}} on {{date}} at {{time}}.</div>
     </div>
   </div>
-  <div id="view-your-schedule" class="view-your-schedule">
-    <div class="view-your-schedule__button-text">GET YOUR OWN SCHEDULE</div>
+  <div class="subtitle">Want to see your own SXSW schedule?</div>
+  <a href="/login" class="spotify-button">
+    <img id="spotify" src="../images/spotify-button.svg">
+  </a>
+  <div id="green-button-no-text" style="visibility: hidden;" class="spotify-button no-text">
+    <div class="lds-ellipsis" id="loader"><div></div><div></div><div></div><div></div></div>
   </div>
   <script>
-    $('#view-your-schedule').click(function(){
-      window.location.replace("https://www.sxdiscover.com");
-    })
+    $('#spotify').click(function(){
+       // Show loading animation     
+      document.getElementById("green-button-no-text").style.visibility = "visible"
+    });
   </script>
 </body>
 </html>

--- a/views/summary.html
+++ b/views/summary.html
@@ -3,7 +3,7 @@
 <head>
   <title></title>
   <link rel="stylesheet" href="/stylesheets/reset.css">
-  <link rel="stylesheet" href="/stylesheets/show.css">
+  <link rel="stylesheet" href="/stylesheets/summary.css">
   <meta name="viewport" content="width=device-width initial-scale = 1.0
   maximum-scale=1.0 user-scalable=no" />
   <script>
@@ -19,10 +19,50 @@
 </head>
 <body>
   <div class="container">
+    <!-- if top or saved, show those -->
+    {{#if topOrSaved}}
+    <div class="helper">Woohoo! Check out these artists from your Spotify who are playing at SXSW this year:</div>
+    <div id="band" class="band">
+      {{#each topOrSaved}}
+      <div class="band__name">{{this}}</div>
+      {{/each}}
+    </div>
 
-  </div>
-  <div id="view-all-results" class="view-all-results">
-    <div class="view-all-results__button-text">VIEW ALL RESULTS</div>
-  </div>
-</body>
-</html>
+    {{else}}
+    <!-- if no top or saved, default to related  -->
+    {{#if related}}
+    <div class="helper">Based on the artists you love, here’s are some related artists playing at SXSW this year:</div>
+    <div id="band" class="band">
+      {{#each related}}
+      <div class="band__name">{{this}}</div>
+      {{/each}}
+    </div>
+
+    {{else}}
+    <!-- show placehodler text if no bands at all-->
+    <div class="helper" align="center">No shows found yet 😞</div><p><p>
+      <div class="no-shows-placeholder">Don't worry – new shows are added every day. Check back soon!</div>
+      {{/if}}
+      {{/if}}
+
+    </div>
+    <div id="view-all-results" class="view-all-results">
+      <div class="view-all-results__button-text">VIEW ALL RESULTS</div>
+    </div>
+    <script>
+      var user = "{{name}}";
+
+      $('#view-all-results').click(function(){
+        $.get( '/pages/'+user, function(data) {
+          console.log("Running /pages function");
+          if (data.hasOwnProperty('errors')){
+            console.log(data);
+            window.location.replace("https://www.sxdiscover.com/404");
+          }
+          window.location.replace("/pages/"+user);
+        });
+      })
+
+    </script>
+  </body>
+  </html>


### PR DESCRIPTION
Wow, I went down a rabbit hole for this one. Here's what I'm thinking:
- Create a new route that displays a full page preview of an individual show
- When you share an individual show, we copy a direct link to _just_ that show. Friends who access that link will see an option to fetch their own schedule.

Ideally it'd look like this (if say you went to sxdiscover.com/show/showId):
<img width="426" alt="screenshot 2019-02-12 21 30 26" src="https://user-images.githubusercontent.com/12538763/52685022-d23ffd00-2f0d-11e9-99a2-712d01701a32.png">

With this diff, it currently looks like this (there were some complications fetching album art from Spotify but that's for a future diff):
<img width="390" alt="screenshot 2019-02-12 21 30 19" src="https://user-images.githubusercontent.com/12538763/52685034-d9ffa180-2f0d-11e9-869f-356d05140d13.png">