### PR TITLE
Removed references to calendar from results page

### DIFF
--- a/views/userPage.html
+++ b/views/userPage.html
@@ -52,142 +52,57 @@
         fjs.parentNode.insertBefore(js, fjs);
       }(document, 'script', 'facebook-jssdk'));
     </script>
-    <script>
-      
-      // If we're redirected to this page from a Google Auth, we add ?auth=true to the URL.
-      // Check if "auth=true" exists and show a success toast that the calendar event was added.
-      window.onload = function(){
-        var param = window.location.search.substring(1) 
-        if(param.includes("auth")){
-          showToast("Show added to calendar.");
-        }
-      }
 
-      // Function to show toast at the top
-      function showToast(text) {
-      var x = document.getElementById("snackbar");
-      x.innerHTML = text;
-      x.className = "display";
-      // After 3 seconds, remove the show class from DIV
-      setTimeout(function(){ x.className = x.className.replace("show", ""); }, 2500);
-    }
+  <div class="add-shows-tooltip">
+    <div class="add-shows-tooltip__text">Add shows to your schedule</div>
+  </div>
 
-      // Function that adds an event handler for each "Save to calendar button". index tells us which date and show the "Save to calendar" button was clicked for.
-      function addCalendarButtonEventHandler(index, name, venue, date, time, link){
-        var year = (new Date()).getFullYear() // Get current year
-        var month = 3 // Assuming all shows are in March
-        var hour = Date.parse(time).getHours()
-        var min = Date.parse(time).getMinutes()
-        var endHour;
-        if(hour==23){
-          endHour = 0
-        } else {
-          endHour = hour+1
-        }
+  <div class="showlist">
+    {{#if shows}}
+    <form name="showsForm">
+      {{#each shows}}
+      <div class="show__day">{{this.day}}, March {{this.date}}</div>
+      {{#each shows}}
+      <div class="show">
+        <div class="show__time-wrapper">
+          <div class="show__time">{{this.time}}</div>
+        </div>
+        <div class="show__info">
+          <a href="{{this.link}}" target="_blank"><div class="show__band">{{this.name}}</div></a>
+          <h3 class="show__source">{{this.source}}</h3>
+          <h3 class="show__venue">{{this.venue}}</h3>
+          <h3 class="show__price">{{this.price}}</h3>
+        </div>
 
-        var startDateTime = year+"-"+month+"-"+date+"T"+hour+":"+min+":00"
-        var endDateTime = year+"-"+month+"-"+date+"T"+endHour+":"+min+":00"
-
-        var eventData = {
-          'summary': 'SXSW: '+name,
-          'location': venue,
-          'description': link,
-          'start': startDateTime,
-          'end': endDateTime,
-          'currentURL':window.location.href
-        }
-
-        $("#saveToCalendar-"+index).click(function(e){
-          console.log("Save to calendar button clicked!")
-          e.preventDefault();
-          $.ajax({
-            datatype:"json",
-            type: 'POST',
-            url: '/calendar',
-            data: eventData,
-            success: function(result){
-              if(result.status==200){
-                showToast("Show added to calendar.");
-                // some UI indication that the calendar event was added
-              }
-              if(result.status==500){
-                // some UI indication that the calendar event was not added
-                showToast("Error adding show to calendar.");
-              }
-              if(result.status==403){
-               window.location.assign(result.redirectURI);
-             }
-           }
-         });
-        })
-      }
-      </script>
-
-      <div class="add-shows-tooltip">
-        <div class="add-shows-tooltip__text">Add shows to your schedule</div>
+        <!-- generate plus buttons for each show -->
+        <input type="checkbox" id="checkbox-{{this.showId}}" class="show__add-button" />
+        <label for="checkbox-{{this.showId}}" />
       </div>
+      {{/each}}
+      {{/each}}
+    </form>
+    {{else}}
+  </div> 
+  <br /><br />
+  <div class="no-shows-placeholder">No shows found yet 😞</div>
+  <div class="no-shows-placeholder">Don't worry – new shows are added every day. Check back soon!</div>
+  {{/if}}
+</div>
+<div class="go-to-schedule" id="go-to-schedule" onclick="getCheckedShows()">
+  <div class="go-to-schedule__button-text">
+    Go to schedule
+  </div>
+</div>
 
-      <div class="showlist">
-        {{#if shows}}
-        <form name="showsForm">
-          {{#each shows}}
-          <div class="show__day">{{this.day}}, March {{this.date}}</div>
-          {{#each shows}}
-          <div class="show">
-            <div class="show__time-wrapper">
-              <div class="show__time">{{this.time}}</div>
-            </div>
-            <div class="show__info">
-              <a href="{{this.link}}" target="_blank"><div class="show__band">{{this.name}}</div></a>
-              <h3 class="show__source">{{this.source}}</h3>
-              <h3 class="show__venue">{{this.venue}}</h3>
-              <h3 class="show__price">{{this.price}}</h3>
-              <div id="saveToCalendar-{{@../index}}-{{@index}}" class="calendar-button">Save to calendar</div>
-            </div>
-
-            <script>
-              var name = "{{this.name}}"
-              var venue = "{{this.venue}}"
-              var date = "{{../this.date}}"
-              var time = "{{this.time}}"
-              var link = "{{this.link}}"
-              addCalendarButtonEventHandler("{{@../index}}-{{@index}}",name,venue,date,time,link)
-            </script>
-            
-            <!-- generate plus buttons for each show -->
-            <input type="checkbox" id="checkbox-{{this.showId}}" class="show__add-button" />
-              <label for="checkbox-{{this.showId}}" />
-
-            <script>
-
-            </script>
-
-          </div>
-          {{/each}}
-          {{/each}}
-        </form>
-        {{else}}
-      </div> 
-      <br /><br />
-      <div class="no-shows-placeholder">No shows found yet 😞</div>
-      <div class="no-shows-placeholder">Don't worry – new shows are added every day. Check back soon!</div>
-      {{/if}}
-    </div>
-    <div class="go-to-schedule" id="go-to-schedule" onclick="getCheckedShows()">
-      <div class="go-to-schedule__button-text">
-        Go to schedule
-      </div>
-    </div>
-
-    <script>
-      function getCheckedShows(form){
-        var savedShows = [];
+<script>
+  function getCheckedShows(form){
+    var savedShows = [];
 
         // get all checked checkboxes
         var checkboxes = document.querySelectorAll("input[type=checkbox]");
         for(var i = 0; i < checkboxes.length; i++ ){
           if(checkboxes[i].checked == true){
-            
+
             // checkbox ids are formatted as `checkboxes-<showId>`
             // strip first 11 chars to get just showId
             var thisShowId = checkboxes[i].id.substr(11,);


### PR DESCRIPTION
Cleaning up the `userpage.html` file and removing any references to the calendar.

The calendar code is stored in the `schedule-sandbox.html` file for now. Will eventually port over to new schedule page.