### PR TITLE
Removed "add shows" header and added toast

### DIFF
--- a/public/stylesheets/userpage.css
+++ b/public/stylesheets/userpage.css
@@ -37,7 +37,6 @@ label {
 
 .showlist{
     margin: 0 auto;
-    margin-top: 6em;
     margin-bottom: 10em;
 }
 
@@ -120,13 +119,11 @@ label {
     visibility: hidden;
     position: fixed;
     bottom: 0;
-    font-weight: 800;
-    font-size: 1.5em;
     display: table;
     text-align: center;
     width: 100%;
     background-color: #32ABB7;
-    height: 4em;
+    height: 6em;
 }
 
 .go-to-schedule:hover{
@@ -135,9 +132,20 @@ label {
     cursor: pointer;
 }
 
-.go-to-schedule__button-text{
+.go-to-schedule__cell{
     display: table-cell;
     vertical-align: middle;
+}
+
+.go-to-schedule__button-text{
+    font-weight: 800;
+    font-size: 1.8em;
+}
+
+.go-to-schedule__subtitle-text{
+    font-weight: 500;
+    font-size: 0.8em;
+    margin-top: 0.3em;
 }
 
 a{

--- a/views/userPage.html
+++ b/views/userPage.html
@@ -67,6 +67,10 @@
         $('input[type=checkbox]').click(function(){
           document.getElementById("go-to-schedule").style.visibility = "visible"
         });
+
+        //
+        vex.dialog.buttons.YES.text = 'Got it'
+        vex.dialog.alert({ message: "Here are the SXSW shows you should go to. Click the + button to add a show to your schedule." })
       });
 
       // Function to show toast at the top
@@ -129,10 +133,6 @@
       }
     </script>
 
-    <div class="add-shows-tooltip">
-      <div class="add-shows-tooltip__text">Add shows to your schedule</div>
-    </div>
-
     <div class="showlist">
       {{#if shows}}
       <form name="showsForm">
@@ -176,9 +176,14 @@
     {{/if}}
   </div>
   <div class="go-to-schedule" id="go-to-schedule" onclick="getCheckedShows()">
-    <div id="go-to-schedule" class="go-to-schedule__button-text">
-      Go to schedule
-    </div>
+    <div class="go-to-schedule__cell">
+      <div id="go-to-schedule" class="go-to-schedule__button-text">
+        Go to schedule
+      </div>
+      <div class="go-to-schedule__subtitle-text">
+        Don't worry. You can come back to this list later.
+      </div>
+    </div>  
   </div>
 
   <script>


### PR DESCRIPTION
Minor change to results page: Removing the header entirely since tapping the plus button feels intuitive (from testing with people). Also added a subtitle to the bottom button so people don't feel like they're losing this full list when they go to the schedule.

NOTE: Toast copy isn't great and could do with a rewrite.

![toast in results page](https://user-images.githubusercontent.com/12538763/52905579-c00dd980-3201-11e9-983e-9b021c595fbc.gif)