### PR TITLE
Increased font weight for add button

### DIFF
--- a/public/images/add-button.svg
+++ b/public/images/add-button.svg
@@ -1,15 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
 <svg width="35px" height="35px" viewBox="0 0 35 35" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g id="simple" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="2---List-view---dark-mode" transform="translate(-322.000000, -120.000000)">
-            <g id="Content" transform="translate(0.000000, 92.000000)">
-                <g id="janelle-plus" transform="translate(322.000000, 28.000000)">
+        <g id="2---List-view---dark-mode" transform="translate(-322.000000, -93.000000)">
+            <g id="Content" transform="translate(0.000000, 65.000000)">
+                <g id="plus-button" transform="translate(322.000000, 28.000000)">
                     <circle id="Oval" fill="#FFFFFF" cx="17.5" cy="17.5" r="17.5"></circle>
-                    <text id="+" font-family="Raleway-Medium, Sharp Grotesk DB Book" font-size="30" font-style="expanded" font-weight="300" fill="#383838">
-                        <tspan x="9.07" y="28">+</tspan>
-                    </text>
+                    <polygon id="+" fill="#383838" fill-rule="nonzero" points="23.692 15.736 23.692 18.4 19.326 18.4 19.326 23.136 16.366 23.136 16.366 18.4 12 18.4 12 15.736 16.366 15.736 16.366 11 19.326 11 19.326 15.736"></polygon>
                 </g>
             </g>
         </g>


### PR DESCRIPTION
So it looks more clickable:
<img width="389" alt="screenshot 2019-02-18 16 24 36" src="https://user-images.githubusercontent.com/12538763/52979106-c8991800-3399-11e9-84e1-51cd7cc8a3af.png">
