### PR TITLE
Updated spacing in summary page

### DIFF
--- a/public/stylesheets/loader.css
+++ b/public/stylesheets/loader.css
@@ -8,10 +8,8 @@
 }
 
 .lds-ellipsis.summary {
-  position: fixed;
-  visibility: hidden;
-  height: 4.4em;
   bottom: 0;
+  padding-bottom: 1em;
 }
 
 .lds-ellipsis div {

--- a/public/stylesheets/summary.css
+++ b/public/stylesheets/summary.css
@@ -6,6 +6,7 @@ body {
 
 .container{
     margin: 0 auto;
+    margin-bottom: 5em;
     padding-left: 2em;
     padding-right: 2em;
 }
@@ -30,7 +31,6 @@ body {
 .band{
     font-size: 2em;
     font-weight: 800;
-    margin-bottom: 4em;
 }
 
 .band__name{
@@ -40,7 +40,6 @@ body {
 /* Setting it up as a table so I can get vertically center the button text */
 .view-all-results{
     position: fixed;
-    bottom: 0;
     font-weight: 800;
     font-size: 1.5em;
     display: table;
@@ -85,5 +84,7 @@ and (min-device-width: 550px) {
 @media only screen
 and (min-device-width: 320px)
 and (max-device-width: 550px) {
-
+    .view-all-results{
+        bottom: 0;
+    }
 }

--- a/views/summary.html
+++ b/views/summary.html
@@ -51,8 +51,9 @@
     {{/if}}
 
     </div>
-    <div class="lds-ellipsis summary" id="loader"><div></div><div></div><div></div><div></div></div>
+    
     <div class="view-all-results hidden" id="button-no-text">
+      <div class="lds-ellipsis summary" id="loader"><div></div><div></div><div></div><div></div></div>
     </div>
     <div id="view-all-results" class="view-all-results">
       <div id="text" class="view-all-results__button-text">VIEW ALL RESULTS</div>


### PR DESCRIPTION
Removed some of the awkward spacing on this page and addressed feedback from two users that the "View all results" button fixed to the bottom feels awkward on web.

<img width="1440" alt="screenshot 2019-02-23 21 48 23" src="https://user-images.githubusercontent.com/12538763/53294855-b31a5880-37b4-11e9-8a54-af31932ac6db.png">

<img width="409" alt="screenshot 2019-02-23 21 48 40" src="https://user-images.githubusercontent.com/12538763/53294856-b57cb280-37b4-11e9-8d1d-e5788ff259b7.png">
