### PR TITLE
fixing summary page view-all-results bug

### DIFF
--- a/public/stylesheets/summary.css
+++ b/public/stylesheets/summary.css
@@ -31,6 +31,7 @@ body {
 .band{
     font-size: 2em;
     font-weight: 800;
+    margin-bottom: 5em;
 }
 
 .band__name{
@@ -69,7 +70,7 @@ body {
 @media only screen
 and (min-device-width: 550px) {
     .container{
-        margin-top: 25vh;
+        margin-top: 15vh;
         width: 400px;
     }
 
@@ -77,6 +78,7 @@ and (min-device-width: 550px) {
         width: 400px;
         left: 50%;
         transform: translateX(-50%);
+        bottom: 0;
     }
 }
 


### PR DESCRIPTION
We hadn't tested the summary page for cases when the user gets lots of related artists. It turns out it spills off the page and the button becomes unclickable. (It was broken on both mobile and desktop)

This diff makes the button stick to the bottom of the user's window regardless of window size. Tested on both iPhone X and desktop res. 

Before:
<img width="940" alt="screenshot 2019-02-27 10 14 53" src="https://user-images.githubusercontent.com/13950154/53505028-acbc0300-3a78-11e9-8e4e-9a35878db2a1.png">

After:
<img width="933" alt="screenshot 2019-02-27 10 15 05" src="https://user-images.githubusercontent.com/13950154/53505029-acbc0300-3a78-11e9-9c70-4c9131ca44cc.png">
